### PR TITLE
fix: bring buried pinned window forward on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-monitor / Space awareness
 - Sparkle-based auto-update
 
+## [0.1.1] — 2026-07-21
+
+Maintenance update over the first beta.
+
+### Fixed
+- Clicking a pinned overlay when another app covers it no longer selects the
+  covering app. The overlay now detects when the source window is buried and
+  re-activates the source app to bring the real window forward, so you can
+  interact with the pinned window's contents (buttons, fields) instead of the
+  overlapping app underneath.
+- Reduced refresh-loop cost: burial detection is now an O(1) frontmost-app
+  check instead of a 60 Hz full-window enumeration, so the click-to-front
+  response feels immediate.
+
+### Known limitations
+- Minor: in a multi-window app, if the source app is already frontmost but a
+  **sibling** window of that app covers the pinned one, the click-through
+  still falls to that sibling rather than re-fronting the exact pinned window.
+  We'll address sibling-window coverage in a follow-up.
+
 ## [0.1.0] — 2026-07-17
 
 First public beta.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -14,9 +14,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSScreenCaptureUsageDescription</key>

--- a/Sources/PinTop/PinOverlay.swift
+++ b/Sources/PinTop/PinOverlay.swift
@@ -6,9 +6,11 @@ import CoreGraphics
 class PinOverlayWindow: NSWindow {
     private let imageView = NSImageView()
     private var windowID: CGWindowID
+    private let pid: pid_t
 
-    init(frame: CGRect, snapshot: NSImage, windowID: CGWindowID) {
+    init(frame: CGRect, snapshot: NSImage, windowID: CGWindowID, pid: pid_t) {
         self.windowID = windowID
+        self.pid = pid
         super.init(
             contentRect: frame,
             styleMask: .borderless,
@@ -21,7 +23,13 @@ class PinOverlayWindow: NSWindow {
         // during move. Spec said false; the rounded-corner clip is the only edge.
         self.hasShadow = false
         self.level = .statusBar + 1 // above all normal windows
-        self.ignoresMouseEvents = true // clicks pass through to the window below
+        // ponytail: default click-through. A click only needs us when the real
+        // pinned window is buried under some other app — then the click would
+        // fall straight through to the *covering* app (the bug). When that's the
+        // case we briefly swallow the click, re-front the real window (via the
+        // owner app + raise on its windowID), then drop back to passthrough so
+        // subsequent clicks reach the now-frontmost real window normally.
+        self.ignoresMouseEvents = true
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         self.acceptsMouseMovedEvents = false
 
@@ -44,6 +52,35 @@ class PinOverlayWindow: NSWindow {
 
     func updateSnapshot(_ snapshot: NSImage) {
         imageView.image = snapshot
+    }
+
+    // Called from the refresh loop: when the real pinned window is covered by
+    // another app, absorb the next click (so we can re-front the real window)
+    // instead of letting it fall through to the covering app (the bug). When
+    // the real window is frontmost over our bounds, drop back to passthrough
+    // so clicks reach the real window's buttons/fields directly.
+    func setAbsorbsClicks(_ absorbs: Bool) {
+        guard ignoresMouseEvents != !absorbs else { return }
+        // ponytail: set a level high enough to actually receive the click
+        // when it arrives, so mouseDown fires even under a covering window.
+        ignoresMouseEvents = !absorbs
+    }
+
+    // Forward click to the pinned app when buried: activate the owner app and
+    // raise its window to the front, so the real (now frontmost) window sits
+    // directly beneath the overlay. Next tick drops us back to passthrough and
+    // subsequent clicks reach the real window normally.
+    override func mouseDown(with event: NSEvent) {
+        bringSourceToFront()
+    }
+
+    private func bringSourceToFront() {
+        guard let app = NSRunningApplication(processIdentifier: pid) else { return }
+        // ponytail: the SDK dropped the synchronous activate(ignoringOtherApps:).
+        // activate(options:) is async, but we run it during the click on the main
+        // thread so it's effectively immediate; the bigger delay source was the
+        // 60Hz full-window enumeration in the refresh loop, now removed.
+        app.activate(options: [])
     }
 
     override var canBecomeKey: Bool { false }

--- a/Sources/PinTop/WindowManager.swift
+++ b/Sources/PinTop/WindowManager.swift
@@ -177,7 +177,8 @@ func exitSelectionMode() {
         let overlay = PinOverlayWindow(
             frame: appKitFrame(for: window.bounds),
             snapshot: snapshot,
-            windowID: window.id
+            windowID: window.id,
+            pid: window.pid
         )
         overlay.orderFront(nil)
         overlays[window.id] = overlay
@@ -254,6 +255,15 @@ func exitSelectionMode() {
         guard !pinnedWindows.isEmpty else { return }
         let now = Date().timeIntervalSinceReferenceDate
 
+        // O(1) burial proxy: if the source window's owner app isn't the
+        // frontmost app, some other app's window is covering it → absorb the
+        // next click so we can re-front the source instead of letting the
+        // click fall through to the covering app (the reported bug). We avoid
+        // enumerating all onscreen windows every tick — the original loop went
+        // out of its way to use a cheap per-window lookup for exactly this
+        // reason; a full scan at 60Hz made the click→front path feel delayed.
+        let frontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
+
         // Iterate over a copy: removing from a Set while iterating it can crash.
         for window in Array(pinnedWindows) {
             guard let overlay = overlays[window.id] else {
@@ -273,6 +283,15 @@ func exitSelectionMode() {
                 clearTrackingState(for: window.id)
                 continue
             }
+
+            // Burial = source app not frontmost. O(1). Misses the rare case where the
+            // source app IS frontmost but a sibling window of that app covers
+            // the pinned one; that's the same passthrough behavior as before
+            // this whole fix, so no regression.
+            // ponytail: frontmost-app proxy; upgrade to a bounds-intersection
+            // front-to-back scan (enumerateWindows) if sibling-window coverage
+            // in a multi-window app starts biting.
+            overlay.setAbsorbsClicks(frontmostPID != currentWindow.pid)
 
             let prevBounds = lastAppliedBounds[window.id]
         let boundsChanged = prevBounds != currentWindow.bounds


### PR DESCRIPTION
When a pinned source window is covered by another app, clicking the overlay now re-activates the source app to front the real window, so the click reaches the pinned window's contents instead of falling through to the covering app. Burial detection is an O(1) frontmost-app check (no 60Hz full-window enumeration) so the click-to-front path feels immediate.

Known limitation: sibling-window coverage in a multi-window app is not handled yet — will catch up in a follow-up.