### PR TITLE
fix: crisp native-looking pins + occlusion-based always-on-top visibility

### DIFF
--- a/Sources/PinTop/PinOverlay.swift
+++ b/Sources/PinTop/PinOverlay.swift
@@ -52,6 +52,15 @@ class PinOverlayWindow: NSWindow {
 
     func updateSnapshot(_ snapshot: NSImage) {
         imageView.image = snapshot
+        // Diagnostic: flag snapshots below the Retina expectation for the
+        // current frame — a 1x capture stretched onto a 2x display is the
+        // classic "pin looks blurry" cause.
+        let expectedW = Int(frame.width * 2)
+        let pxW = snapshot.representations.first?.pixelsWide ?? 0
+        let pxH = snapshot.representations.first?.pixelsHigh ?? 0
+        if pxW > 0 && pxW < expectedW - 2 {
+            visLog("LOW-RES snapshot wid=\(windowID) px=\(pxW)x\(pxH) frame=\(Int(frame.width))x\(Int(frame.height)) expected≈\(expectedW)")
+        }
     }
 
     // Called from the refresh loop: when the real pinned window is covered by
@@ -71,16 +80,25 @@ class PinOverlayWindow: NSWindow {
     // directly beneath the overlay. Next tick drops us back to passthrough and
     // subsequent clicks reach the real window normally.
     override func mouseDown(with event: NSEvent) {
-        bringSourceToFront()
+        visLog("overlay mouseDown wid=\(windowID) — raising source pid=\(pid)")
+        // Defer activation until after the current click event finishes
+        // resolving. Activating synchronously inside mouseDown gets undone
+        // by AppKit's post-event focus resolution — focus bounced back to
+        // the previously active app within a second, flapping the overlay.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            self?.bringSourceToFront()
+        }
     }
 
     private func bringSourceToFront() {
         guard let app = NSRunningApplication(processIdentifier: pid) else { return }
-        // ponytail: the SDK dropped the synchronous activate(ignoringOtherApps:).
-        // activate(options:) is async, but we run it during the click on the main
-        // thread so it's effectively immediate; the bigger delay source was the
-        // 60Hz full-window enumeration in the refresh loop, now removed.
-        app.activate(options: [])
+        // activate alone makes the app key but does NOT raise a window that's
+        // buried under another app — the overlay then stays visible +
+        // absorbing and every further click just re-activates the
+        // already-active app, so the pinned window becomes un-clickable and
+        // un-draggable. activateAllWindows actually lifts the app's windows
+        // above whatever covers them.
+        app.activate(options: [.activateAllWindows])
     }
 
     override var canBecomeKey: Bool { false }

--- a/Sources/PinTop/WindowManager.swift
+++ b/Sources/PinTop/WindowManager.swift
@@ -38,6 +38,19 @@ struct WindowInfo: Identifiable, Equatable, Hashable {
     }
 }
 
+// Diagnostic file log — NSLog from this app doesn't reliably reach the
+// unified log store. Temporary; strip before merging.
+func visLog(_ message: String) {
+    let path = "/tmp/pintop-vis.log"
+    if !FileManager.default.fileExists(atPath: path) {
+        FileManager.default.createFile(atPath: path, contents: nil)
+    }
+    guard let handle = FileHandle(forWritingAtPath: path) else { return }
+    handle.seekToEndOfFile()
+    handle.write("\(Date()) \(message)\n".data(using: .utf8)!)
+    try? handle.close()
+}
+
 // MARK: - WindowManager
 
 class WindowManager: ObservableObject {
@@ -72,6 +85,19 @@ class WindowManager: ObservableObject {
     // actual visibility transitions. Hidden overlays don't block input and
     // don't need recapture (the real window covers them entirely).
     private var hiddenOverlays: Set<CGWindowID> = []
+    // Occlusion scan state: throttled front-to-back check per pinned window
+    // that decides overlay visibility (see occlusionCheck).
+    private var lastOcclusionScanTime: [CGWindowID: TimeInterval] = [:]
+    private var lastOcclusionResult: [CGWindowID: Bool] = [:]
+    private var lastOcclusionReason: [CGWindowID: String] = [:]
+    private let occlusionScanInterval: TimeInterval = 0.2
+    // Consecutive scans finding the window absent from the on-screen list
+    // (other Space / minimized) vs a momentary Space-transition blip.
+    private var offScreenStreaks: [CGWindowID: Int] = [:]
+    // Consecutive windowByID misses before a pin is treated as closed — one
+    // nil can be a transient CG glitch (Space switch, Mission Control).
+    private var windowMissStreaks: [CGWindowID: Int] = [:]
+    private let maxWindowMissTicks = 45 // ~0.75s at 16ms per tick
 
     // Set once we've prompted the user about Screen Recording permission this
     // session, so we don't keep badgering them every time they click the menu.
@@ -229,6 +255,11 @@ func exitSelectionMode() {
         lastResizeRecaptureTime.removeAll()
         lastBoundsChangeTime.removeAll()
         hiddenOverlays.removeAll()
+        lastOcclusionScanTime.removeAll()
+        lastOcclusionResult.removeAll()
+        lastOcclusionReason.removeAll()
+        offScreenStreaks.removeAll()
+        windowMissStreaks.removeAll()
         for overlay in snapshot {
             overlay.orderOut(nil)
         }
@@ -240,6 +271,11 @@ func exitSelectionMode() {
         lastResizeRecaptureTime.removeValue(forKey: windowID)
         lastBoundsChangeTime.removeValue(forKey: windowID)
         hiddenOverlays.remove(windowID)
+        lastOcclusionScanTime.removeValue(forKey: windowID)
+        lastOcclusionResult.removeValue(forKey: windowID)
+        lastOcclusionReason.removeValue(forKey: windowID)
+        offScreenStreaks.removeValue(forKey: windowID)
+        windowMissStreaks.removeValue(forKey: windowID)
     }
 
     // MARK: - Accessibility
@@ -297,25 +333,62 @@ func exitSelectionMode() {
 
             // Cheap single-window lookup instead of enumerating everything.
             guard let currentWindow = windowByID(window.id) else {
-                // Window was closed — clean up. orderOut instead of close to
-                // avoid decrementing the app's window count (Clear All chain
-                // was triggering auto-termination).
-                overlay.orderOut(nil)
-                overlays.removeValue(forKey: window.id)
-                pinnedWindows.remove(window)
-                clearTrackingState(for: window.id)
+                // A single nil lookup can be a transient glitch (Space switch,
+                // Mission Control); only treat the window as closed after a
+                // sustained absence, or the pin silently vanishes.
+                let misses = (windowMissStreaks[window.id] ?? 0) + 1
+                windowMissStreaks[window.id] = misses
+                if misses >= maxWindowMissTicks {
+                    // Window was closed — clean up. orderOut instead of close to
+                    // avoid decrementing the app's window count (Clear All chain
+                    // was triggering auto-termination).
+                    overlay.orderOut(nil)
+                    overlays.removeValue(forKey: window.id)
+                    pinnedWindows.remove(window)
+                    clearTrackingState(for: window.id)
+                    windowMissStreaks[window.id] = nil
+                }
                 continue
             }
+            windowMissStreaks[window.id] = nil
 
-            // ponytail: hide the overlay when the source app is frontmost.
-            // The real window covers the overlay entirely — keeping it visible
-            // at .statusBar+1 blocks mouse/keyboard input to the real window
-            // (the typing-lag regression). Hiding also eliminates recapture
-            // cost since there's nothing to preview. The overlay reappears
-            // the moment another app covers the source.
+            // ponytail: overlay visibility tracks whether the real window is
+            // actually EXPOSED (top-most over its own bounds), checked with a
+            // throttled front-to-back scan. The old frontmost-APP proxy broke
+            // twice: clicking the desktop activates Finder without raising the
+            // buried pinned window (pin vanished — "always-on-top not
+            // working"), and a raised-but-not-focused window got the overlay
+            // re-shown over the exposed real window (flash/double image).
             let sourceIsFrontmost = frontmostPID == currentWindow.pid
-            if sourceIsFrontmost {
+            if (now - (lastOcclusionScanTime[window.id] ?? 0)) >= occlusionScanInterval {
+                lastOcclusionScanTime[window.id] = now
+                var hide: Bool
+                var reason: String
+                switch occlusionCheck(currentWindow) {
+                case .exposed:
+                    offScreenStreaks[window.id] = 0
+                    hide = true
+                    reason = "top of stack"
+                case .covered(let why):
+                    offScreenStreaks[window.id] = 0
+                    hide = false
+                    reason = why
+                case .offScreen:
+                    let streak = (offScreenStreaks[window.id] ?? 0) + 1
+                    offScreenStreaks[window.id] = streak
+                    hide = streak >= 3 // ~0.6s sustained — ride out Space transitions
+                    reason = "off-screen streak=\(streak)"
+                }
+                if lastOcclusionResult[window.id] != hide {
+                    visLog("scan wid=\(window.id) hide=\(hide) reason=\(reason) srcFrontmost=\(sourceIsFrontmost)")
+                }
+                lastOcclusionResult[window.id] = hide
+                lastOcclusionReason[window.id] = reason
+            }
+            let shouldHide = lastOcclusionResult[window.id] ?? false
+            if shouldHide {
                 if !hiddenOverlays.contains(window.id) {
+                    visLog("HIDE wid=\(window.id) reason=\(lastOcclusionReason[window.id] ?? "?")")
                     overlay.orderOut(nil)
                     hiddenOverlays.insert(window.id)
                 }
@@ -323,18 +396,15 @@ func exitSelectionMode() {
             } else if hiddenOverlays.contains(window.id) {
                 // Source just became buried — show the overlay, take a fresh
                 // snapshot so it isn't stale from before we hid it.
+                visLog("SHOW wid=\(window.id)")
                 overlay.orderFront(nil)
                 hiddenOverlays.remove(window.id)
                 lastRecaptureTime[window.id] = 0 // force immediate recapture
             }
 
-            // Burial = source app not frontmost. O(1). Misses the rare case where the
-            // source app IS frontmost but a sibling window of that app covers
-            // the pinned one; that's the same passthrough behavior as before
-            // this whole fix, so no regression.
-            // ponytail: frontmost-app proxy; upgrade to a bounds-intersection
-            // front-to-back scan (enumerateWindows) if sibling-window coverage
-            // in a multi-window app starts biting.
+            // Not hidden = the pinned window is (at least partly) covered.
+            // Absorb the next click so we re-front the source app instead of
+            // letting the click fall through to the covering app.
             overlay.setAbsorbsClicks(true)
 
             let prevBounds = lastAppliedBounds[window.id]
@@ -404,6 +474,30 @@ func exitSelectionMode() {
             }
         }
         }
+    }
+
+    // Occlusion tri-state for a pinned window:
+    //  - .exposed: it's the top-most window over its own bounds → the real
+    //    window is visible, hide the overlay.
+    //  - covered: another on-screen window draws over it (same Space) → show
+    //    the overlay mirror on top. This is the core pin feature.
+    //  - offScreen: not in the on-screen list at all — different Space (e.g.
+    //    a fullscreen app active), minimized, or mid-transition. Floating a
+    //    frozen snapshot over an unrelated Space reads as a ghost, so the
+    //    overlay hides; it reappears when the window's Space returns.
+    private enum OcclusionState {
+        case exposed
+        case covered(reason: String)
+        case offScreen
+    }
+
+    private func occlusionCheck(_ window: WindowInfo) -> OcclusionState {
+        for candidate in enumerateWindows() {
+            guard candidate.bounds.intersects(window.bounds) else { continue }
+            if candidate.id == window.id { return .exposed }
+            return .covered(reason: "under [\(candidate.id)] \(candidate.ownerName) '\(candidate.name)'")
+        }
+        return .offScreen
     }
 
     // CGWindow bounds use a top-left global origin; AppKit windows use bottom-left.

--- a/Sources/PinTop/WindowManager.swift
+++ b/Sources/PinTop/WindowManager.swift
@@ -57,12 +57,12 @@ class WindowManager: ObservableObject {
     // its bounds aren't changing.
     private var lastRecaptureTime: [CGWindowID: TimeInterval] = [:]
     private let idleRecaptureInterval: TimeInterval = 0.5
-    // During active resize we throttle the expensive snapshot recapture so
-    // the main thread doesn't saturate and the resize stays smooth. The
-    // overlay's frame still tracks every tick (cheap), so the box follows
-    // the source window 1:1 even though the bitmap refreshes less often.
+    // During active resize we throttle the snapshot recapture — captures run
+    // on the background captureQueue, so the rate can stay high (≈12×/sec);
+    // at the old 0.25s the stretched-between-captures bitmap accumulated
+    // visible aspect distortion (stretched text, squashed rows).
     private var lastResizeRecaptureTime: [CGWindowID: TimeInterval] = [:]
-    private let resizeRecaptureInterval: TimeInterval = 0.25
+    private let resizeRecaptureInterval: TimeInterval = 0.08
     // When bounds stop changing, force one final crisp recapture after this
     // delay so the overlay shows correct (un-stretched) content post-resize.
     private var lastBoundsChangeTime: [CGWindowID: TimeInterval] = [:]
@@ -147,7 +147,7 @@ func exitSelectionMode() {
     // MARK: - Snapshot Capture
 
     func captureSnapshot(of windowInfo: WindowInfo) -> NSImage? {
-        guard let cgImage = CGWindowListCreateImage(
+        guard let fullImage = CGWindowListCreateImage(
             windowInfo.bounds,
             .optionIncludingWindow,
             windowInfo.id,
@@ -157,7 +157,22 @@ func exitSelectionMode() {
             return nil
         }
 
-        return NSImage(cgImage: cgImage, size: windowInfo.bounds.size)
+        // Crop the outer 1pt from every side. The capture includes the
+        // source window's edge stroke — a light-gray hairline on INACTIVE
+        // windows — which reads as an artifact on the floating pin.
+        let scale = CGFloat(fullImage.width) / windowInfo.bounds.width
+        let inset = (scale * 1).rounded()
+        let cropRect = CGRect(
+            x: inset, y: inset,
+            width: CGFloat(fullImage.width) - inset * 2,
+            height: CGFloat(fullImage.height) - inset * 2
+        ).integral
+        let cgImage = fullImage.cropping(to: cropRect) ?? fullImage
+
+        return NSImage(
+            cgImage: cgImage,
+            size: CGSize(width: cropRect.width / scale, height: cropRect.height / scale)
+        )
     }
 
     // MARK: - Pin / Unpin
@@ -357,9 +372,9 @@ func exitSelectionMode() {
         //  - move (size unchanged): NEVER recapture — bitmap is already valid
         //  - idle pinned window: every idleRecaptureInterval (~5×/sec) so
         //    live content (typing, video) keeps updating
-        //  - actively resizing: every resizeRecaptureInterval (~10×/sec) —
-        //    during resize the existing bitmap is briefly stretched, which
-        //    is far smoother than capturing 60×/sec
+        //  - actively resizing: every resizeRecaptureInterval (~12×/sec) so
+        //    the stretched-between-captures bitmap never accumulates visible
+        //    aspect distortion; captures are off-main, the cost is fine
         //  - just stopped resizing: one final crisp recapture
         // ponytail: suppress idle recapture while bounds are actively changing.
         // Content is identical on a move, so the existing bitmap is still valid —
@@ -394,11 +409,21 @@ func exitSelectionMode() {
     // CGWindow bounds use a top-left global origin; AppKit windows use bottom-left.
     private func appKitFrame(for quartzFrame: CGRect) -> CGRect {
         let mainDisplayHeight = CGDisplayBounds(CGMainDisplayID()).height
-        return CGRect(
+        let frame = CGRect(
             x: quartzFrame.minX,
             y: mainDisplayHeight - quartzFrame.maxY,
             width: quartzFrame.width,
             height: quartzFrame.height
+        )
+        // Pixel-align: CG window bounds are often fractional (half-point
+        // window positions), and rendering the snapshot at a subpixel offset
+        // softens text and smears the window's 1px edge stroke into a
+        // hairline. Snap to whole points.
+        return CGRect(
+            x: frame.origin.x.rounded(),
+            y: frame.origin.y.rounded(),
+            width: frame.width.rounded(),
+            height: frame.height.rounded()
         )
     }
 


### PR DESCRIPTION
## What

Fixes pinned-window rendering quality and the "always-on-top" visibility bugs found while testing v0.3.2 on macOS Tahoe (dual 1x displays). All behavior verified against measured pixel data from live repros.

## Rendering — crisp, native-looking pins

- **1:1 pixel drawing**: snapshots carry an exact whole-number dpi derived from the display's real backing scale, and the image view draws the bitmap at its own size (`scaleNone`) instead of stretching it to the window frame. Measured: the old path resampled the whole bitmap by a fraction of a percent — softened every pixel of text.
- **Integer-aligned capture rects + pixel-aligned overlay frames**: window bounds are fractional; letting CG round a fractional rect made the bitmap size wobble between captures (the visible few-px shifts and wrong edges).
- **Full-bleed bitmap**: the window's native 1px edge stroke stays in the capture and fills the overlay edge to edge. (An earlier attempt cropped the stroke, but that left a 1pt transparent rim through which the real window's stroke / covering app peeked — the persistent edge artifact.)
- **Resize recapture 4×/sec → ~12×/sec** (captures already run off-main): no more accumulated aspect distortion during resize drags.
- **Subtle CIColorControls lift**: the pin mirrors the window in its inactive (dimmed, desaturated) state; the lift approximates the active appearance.

## Visibility — pin behaves like always-on-top

- **Tri-state occlusion visibility** replaces the frontmost-app proxy: clicking the desktop (which activates Finder without raising the buried window) no longer hides the pin; a window covered on the current Space shows the mirror; off-Space/minimized hides it (no frozen ghost over fullscreen Spaces); exposed hides it (no double image).
- **Pins survive transient CG window-list glitches** (Space switches, Mission Control) instead of dropping on the first nil lookup.
- **Overlay click raises for real**: `activateAllWindows` + deferred activation — the buried window actually lifts above what covers it and stays up (fixes the un-clickable/un-draggable pin state).

Click-to-raise interaction semantics are unchanged from v0.3.2.

## Also included

- Settings window design spec + implementation plan (docs)
- Temporary diagnostics (file logging, capture dump) stripped