### PR TITLE
fix: pin/unpin by window identity; stop orphaned overlays killing the…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,5 +18,10 @@ let package = Package(
             path: "Sources/PinTop",
             resources: [.copy("Resources/PinTop.icns")]
         ),
+        .testTarget(
+            name: "PinTopTests",
+            dependencies: ["PinTop"],
+            path: "Tests/PinTopTests"
+        ),
     ]
 )

--- a/Sources/PinTop/PinOverlay.swift
+++ b/Sources/PinTop/PinOverlay.swift
@@ -5,7 +5,7 @@ import CoreGraphics
 
 class PinOverlayWindow: NSWindow {
     private let imageView = NSImageView()
-    private var windowID: CGWindowID
+    let windowID: CGWindowID
     private let pid: pid_t
 
     init(frame: CGRect, snapshot: NSImage, windowID: CGWindowID, pid: pid_t) {

--- a/Sources/PinTop/SelectionOverlay.swift
+++ b/Sources/PinTop/SelectionOverlay.swift
@@ -18,7 +18,11 @@ class SelectionOverlayWindow: NSWindow {
         )
         self.isOpaque = false
         self.backgroundColor = NSColor.clear
-        self.level = .statusBar + 1
+        // One above pin overlays (statusBar + 1). Pin overlays absorb clicks
+        // while their source window is buried, and the refresh loop keeps
+        // re-fronting them — at the same level they could sit over the
+        // picker and swallow its clicks, reading as "picker dead" (#5).
+        self.level = .statusBar + 2
         self.ignoresMouseEvents = false
         self.acceptsMouseMovedEvents = true
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]

--- a/Sources/PinTop/WindowManager.swift
+++ b/Sources/PinTop/WindowManager.swift
@@ -4,12 +4,25 @@ import Combine
 
 // MARK: - WindowInfo
 
+/// Identity of a window is its CGWindowID. Name and bounds are mutable
+/// attributes (windows move, resize, retitle — a pinned window can drift by
+/// a single pixel between pins), so equality/hashing must key on `id` only.
+/// Field-wise equality made `pinnedWindows.contains` miss a re-selected
+/// window and pin it twice, stranding the first overlay on screen (#5).
 struct WindowInfo: Identifiable, Equatable, Hashable {
     let id: CGWindowID
     let name: String
     let ownerName: String
     let pid: pid_t
     let bounds: CGRect
+
+    static func == (lhs: WindowInfo, rhs: WindowInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
 
     static func fromDictionary(_ dict: [String: Any]) -> WindowInfo? {
         guard
@@ -179,6 +192,12 @@ func exitSelectionMode() {
 
         pinnedWindows.insert(window)
 
+        // If an overlay for this id somehow survives (e.g. state left by an
+        // older build), retire it before installing the new one — replacing
+        // the dict entry alone would strand the old window on screen, where
+        // it keeps absorbing clicks until the app restarts.
+        overlays[window.id]?.orderOut(nil)
+
         // Create overlay window
         let overlay = PinOverlayWindow(
             frame: appKitFrame(for: window.bounds),
@@ -198,6 +217,12 @@ func exitSelectionMode() {
         pinnedWindows.remove(window)
         clearTrackingState(for: window.id)
         overlay?.orderOut(nil)
+        // Also retire any untracked overlay for the same window — an orphan
+        // stranded by a double-pin in an older build would otherwise keep
+        // swallowing clicks in its frame after this unpin (#5).
+        for case let stray as PinOverlayWindow in NSApp.windows where stray.windowID == window.id {
+            stray.orderOut(nil)
+        }
     }
 
     func unpinAll() {
@@ -215,6 +240,13 @@ func exitSelectionMode() {
         lastBoundsChangeTime.removeAll()
         hiddenOverlays.removeAll()
         for overlay in snapshot {
+            overlay.orderOut(nil)
+        }
+        // Sweep any overlay windows no longer tracked in `overlays` — e.g.
+        // orphans stranded by double-pinning in older builds. They sit at
+        // pin level and swallow every click in their frame, which read as
+        // "picker dead until restart" (#5). orderOut (not close) on purpose.
+        for case let overlay as PinOverlayWindow in NSApp.windows {
             overlay.orderOut(nil)
         }
     }

--- a/Tests/PinTopTests/WindowInfoTests.swift
+++ b/Tests/PinTopTests/WindowInfoTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import PinTop
+
+/// Regression tests for issue #5: a window's identity is its CGWindowID.
+/// The old field-wise equality let a window that moved/resized/re-titled
+/// between pins defeat `pinnedWindows.contains`, accepting a second pin and
+/// stranding the first overlay on screen.
+final class WindowInfoTests: XCTestCase {
+    private func makeWindow(
+        id: CGWindowID,
+        name: String = "Window",
+        owner: String = "App",
+        pid: pid_t = 1000,
+        bounds: CGRect = CGRect(x: 0, y: 0, width: 800, height: 600)
+    ) -> WindowInfo {
+        WindowInfo(id: id, name: name, ownerName: owner, pid: pid, bounds: bounds)
+    }
+
+    func testSameIDWithDifferentBoundsIsEqual() {
+        let original = makeWindow(id: 42, bounds: CGRect(x: 417, y: 160, width: 525, height: 547))
+        let moved = makeWindow(id: 42, bounds: CGRect(x: 682, y: 152, width: 525, height: 547))
+        let nudgedOnePixel = makeWindow(id: 42, bounds: CGRect(x: 682, y: 151, width: 525, height: 547))
+        let resized = makeWindow(id: 42, bounds: CGRect(x: 0, y: 30, width: 1920, height: 1050))
+
+        XCTAssertEqual(original, moved)
+        XCTAssertEqual(moved, nudgedOnePixel)
+        XCTAssertEqual(original, resized)
+    }
+
+    func testSameIDWithDifferentTitleIsEqual() {
+        let before = makeWindow(id: 7, name: "Untitled")
+        let retitled = makeWindow(id: 7, name: "My Document — Edited")
+        XCTAssertEqual(before, retitled)
+    }
+
+    func testDifferentIDsAreNotEqual() {
+        XCTAssertNotEqual(makeWindow(id: 1), makeWindow(id: 2))
+    }
+
+    func testHashKeysOnID() {
+        let a = makeWindow(id: 42, bounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let b = makeWindow(id: 42, bounds: CGRect(x: 999, y: 999, width: 525, height: 547))
+        XCTAssertEqual(a.hashValue, b.hashValue)
+
+        var set: Set<WindowInfo> = [a]
+        set.insert(b) // moved copy of the same window must not duplicate
+        XCTAssertEqual(set.count, 1)
+    }
+
+    func testSetContainsReSelectedWindowAfterMove() {
+        // The exact shape of the bug-1 guard: pin, move the window (or have
+        // macOS nudge it a pixel), select it again — contains must hold.
+        var pinned: Set<WindowInfo> = [makeWindow(id: 5608, bounds: CGRect(x: 417, y: 160, width: 525, height: 547))]
+        let reSelected = makeWindow(id: 5608, bounds: CGRect(x: 682, y: 151, width: 525, height: 547))
+        XCTAssertTrue(pinned.contains(reSelected))
+        pinned.insert(reSelected)
+        XCTAssertEqual(pinned.count, 1)
+    }
+}


### PR DESCRIPTION
… picker (#5)

Double-pin: WindowInfo compared every field, so a window that moved, resized, or was nudged a single pixel between pins defeated the pinnedWindows.contains guard — the second pin replaced the overlays dict entry while the old PinOverlayWindow stayed on screen forever. Equality and hashing now key on the CGWindowID only.

Dead picker: those stranded overlays sit at pin level with click absorption on, and Clear All only removed overlays still tracked in the dict, so every click in their frame was swallowed until app restart — the "picker stops working" symptom. pin() now retires any existing overlay for the id before installing a new one, unpin/unpinAll sweep untracked PinOverlayWindows (heals orphans left by older builds), and the selection overlay moves one level above pin overlays so the picker always receives its own clicks.

Adds a PinTopTests target with regression tests for the identity semantics (same id + moved/retitled window must stay one pin).