### PR TITLE
fix: erase stuck duplicate-frame trail during drag/resize (#6)

### DIFF
--- a/Sources/PinTop/WindowManager.swift
+++ b/Sources/PinTop/WindowManager.swift
@@ -188,6 +188,9 @@ func exitSelectionMode() {
         )
         overlay.orderFront(nil)
         overlays[window.id] = overlay
+        // Seed bounds tracking with the frame just applied so the first
+        // refresh tick can already tell a move apart from a resize.
+        lastAppliedBounds[window.id] = window.bounds
     }
 
     func unpin(_ window: WindowInfo) {
@@ -343,10 +346,21 @@ func exitSelectionMode() {
         let settleRecaptureDue = !boundsChanged && lastChange > 0 && (now - lastChange) < settleRecaptureDelay && (now - prevResizeRecapture) >= resizeRecaptureInterval
 
         if boundsChanged {
-            // display:false — let AppKit repaint at the next vsync instead of
-            // forcing a synchronous redraw here.画面 is smoother because we're
-            // not blocking the main thread on paint during a burst of moves.
-            overlay.setFrame(appKitFrame(for: currentWindow.bounds), display: false)
+            let newFrame = appKitFrame(for: currentWindow.bounds)
+            if sizeChanged {
+                // Resize: redraw synchronously at the new size. With
+                // display:false the resized backing store stayed unflushed and
+                // the window server kept compositing stale intermediate
+                // surfaces — the stuck full-opacity frames of issue #6.
+                overlay.setFrame(newFrame, display: true)
+            } else {
+                // Pure move: setFrameOrigin translates the window's surface
+                // inside the window server without touching the backing store,
+                // so there is no lazily-unpainted region to leave behind along
+                // the movement path (issue #6). Also cheaper than setFrame,
+                // which keeps 60Hz move tracking smooth.
+                overlay.setFrameOrigin(newFrame.origin)
+            }
             lastAppliedBounds[window.id] = currentWindow.bounds
             if sizeChanged {
                 lastBoundsChangeTime[window.id] = now


### PR DESCRIPTION
## Summary

Fixes #6 — dragging or resizing a pinned window left full-opacity duplicate frames frozen along the movement path, stacking on the wallpaper underneath.

## Root cause

The 60 Hz refresh loop applied every bounds change to the overlay with `setFrame(_:display: false)`. Lazy repainting meant the previous frame's screen region was never invalidated, so the window server kept compositing stale surfaces — a trail of frozen window snapshots.

## Changes

- **Pure moves** now use `setFrameOrigin(_:)`: the window's surface is translated inside the window server without touching the backing store, so there is no unflushed region to leave behind. This is also cheaper than `setFrame`, keeping 60 Hz move tracking smooth (the original motivation for `display: false`).
- **Resizes** now use `setFrame(_:display: true)`: every intermediate resize step is synchronously redrawn and flushed, so no smear accumulates as the window grows/shrinks.
- Seed `lastAppliedBounds` in `pin()` so the first refresh tick can already distinguish a move from a resize.

## Testing

- [x] `swift build` passes (no new warnings)
- [x] Built, signed, and launched via `./run.sh`; pinned window dragged and resized across the desktop with no duplicate frames or residue left on the wallpaper
- [x] Regression check: idle pinned window still refreshes live content; input to the source window not blocked

This project has no automated test target; verification is manual per `CLAUDE.md`.
