### PR TITLE
fix: pin keeps its active appearance when the source window dims

### DIFF
--- a/Sources/PinTop/WindowManager.swift
+++ b/Sources/PinTop/WindowManager.swift
@@ -51,6 +51,75 @@ struct WindowInfo: Identifiable, Equatable, Hashable {
     }
 }
 
+// MARK: - Inactive-appearance correction
+
+/// A downsampled RGBA8 copy of a capture, small enough to run robust pixel
+/// statistics on without touching the full-resolution bitmap.
+struct DownsampledBitmap {
+    let width: Int
+    let height: Int
+    let rgba: [UInt8]
+}
+
+/// Robust per-channel statistics of a snapshot plus a coarse luma grid.
+/// Feeds both halves of the inactive-appearance measurement: the channel
+/// stats define the inverse transform to fit, and the luma grid gates the
+/// measurement on the content being static (a global tone shift moves every
+/// grid cell by the same amount; real content edits don't).
+struct AppearanceStats: Equatable {
+    var channelMedian = SIMD3<Float>(repeating: 0)
+    /// MAD × 1.4826 (a robust std) per channel, in 0...1 units.
+    var channelSpread = SIMD3<Float>(repeating: 0)
+    /// Mean max−min channel distance, 0...1. Drops to near zero when a
+    /// Chromium-style app desaturates its inactive content.
+    var chromaMean: Float = 0
+    /// Median luma (median of the cell medians), 0...1. Cheap direction
+    /// signal: did the window get brighter or darker than the anchor.
+    var lumaMedian: Float = 0
+    /// Per-cell median luma over a ≤12×12 grid, 0...1.
+    var cellLuma: [Float] = []
+    var cellsX = 0
+    var cellsY = 0
+}
+
+/// Per-window inverse of the source app's dimmed-window appearance, fitted
+/// by comparing a capture against the anchor stats (see correctorDecision).
+/// All values are in 0...1 sRGB units and are applied per-channel in the
+/// same space (see applyCorrection), so no color-space conversion sits
+/// between measurement and application.
+struct AppearanceCorrection: Equatable {
+    /// CIColorControls-style saturation boost applied before the affine
+    /// stage, undoing lerp-toward-gray desaturation the affine can't.
+    var saturation: Float = 1
+    var channelScale = SIMD3<Float>(repeating: 1)
+    var channelBias = SIMD3<Float>(repeating: 0)
+
+    var isIdentity: Bool {
+        saturation == 1
+            && channelScale == SIMD3<Float>(repeating: 1)
+            && channelBias == SIMD3<Float>(repeating: 0)
+    }
+}
+
+/// What the appearance corrector decided about one fresh capture. The pin's
+/// contract is "always read like the ACTIVE window": dimming shifts get
+/// inverted against the anchor, brightening shifts re-anchor, mid-animation
+/// or ambiguous frames freeze on the current bitmap until stable.
+enum AppearanceDecision: Equatable {
+    /// Content change (or no appearance change) — display the capture with
+    /// the current correction; no corrector state changes.
+    case flow(AppearanceCorrection)
+    /// A new transform was confirmed by two consecutive captures — store it
+    /// as the window's correction and display with it.
+    case adopt(AppearanceCorrection)
+    /// Appearance is mid-change (deactivation/focus animation, video fade):
+    /// keep displaying the current bitmap, remember this candidate fit.
+    case freeze(candidate: AppearanceCorrection)
+    /// The window brightened beyond the anchor (key/focus regained): display
+    /// raw and adopt these stats as the new anchor.
+    case reanchor(AppearanceStats)
+}
+
 // MARK: - WindowManager
 
 class WindowManager: ObservableObject {
@@ -128,6 +197,41 @@ class WindowManager: ObservableObject {
     // nil can be a transient CG glitch (Space switch, Mission Control).
     private var windowMissStreaks: [CGWindowID: Int] = [:]
     private let maxWindowMissTicks = 45 // ~0.75s at 16ms per tick
+
+    // MARK: Appearance corrector state (per pinned window)
+    // Apps restyle their windows when they stop being the key/focused
+    // window — the system dims chrome on app deactivation, and Chromium/
+    // Electron apps (Figma plugin windows, Slack, VS Code…) fade their
+    // whole content EVEN WHILE THE APP STAYS FRONTMOST (per-window focus,
+    // not app activation — clicking the Figma canvas behind a pinned plugin
+    // window dims it with no NSWorkspace signal at all). Those pixels are
+    // baked into the capture, so a naive recapture visibly changes the
+    // pin's color (the reported bug). Keyed-on-activation detection misses
+    // the intra-app case, so instead EVERY recapture runs through
+    // correctorDecision: a uniform tone shift vs the previous capture with
+    // static content = appearance change → freeze while it animates, then
+    // adopt the measured inverse once two captures agree; a shift toward
+    // brighter/more-chromatic = focus regained → re-anchor raw; anything
+    // non-uniform = real content change → flow through the current
+    // correction.
+    private enum AppearanceConstants {
+        /// Consecutive frozen frames before giving up on confirmation
+        /// (a video fade drifts every frame and would freeze the pin
+        /// forever; a real deactivation animation settles within ~4).
+        static let maxFreezeStreak = 6
+    }
+    /// The appearance the pin should keep showing: stats of the window in
+    /// its most-active observed state. Ratchets up on brighten, tracks
+    /// content through adopted corrections (mappedStats).
+    private var anchorStats: [CGWindowID: AppearanceStats] = [:]
+    /// Confirmed correction currently applied to dimmed captures.
+    private var activeFit: [CGWindowID: AppearanceCorrection] = [:]
+    /// Unconfirmed candidate fit (waiting for a second agreeing capture).
+    private var pendingFit: [CGWindowID: AppearanceCorrection] = [:]
+    /// Stats of the last RAW capture (adjacent-frame gate reference — raw
+    /// to raw, so adopted corrections don't bias the gate).
+    private var lastCaptureStats: [CGWindowID: AppearanceStats] = [:]
+    private var freezeStreaks: [CGWindowID: Int] = [:]
 
     // Set once we've prompted the user about Screen Recording permission this
     // session, so we don't keep badgering them every time they click the menu.
@@ -223,7 +327,28 @@ func exitSelectionMode() {
 
     // MARK: - Snapshot Capture
 
-    func captureSnapshot(of windowInfo: WindowInfo, sourceIsActive: Bool = true) -> NSImage? {
+    /// Snapshot bookkeeping the corrector needs per capture, snapshotted on
+    /// the main thread when the capture is enqueued.
+    private struct AppearanceContext {
+        let anchor: AppearanceStats
+        let activeFit: AppearanceCorrection
+        let pendingFit: AppearanceCorrection?
+        let lastCapture: AppearanceStats
+        let freezeStreak: Int
+    }
+
+    private struct ProcessedCapture {
+        /// nil when the corrector froze — keep displaying the current bitmap.
+        let image: NSImage?
+        let stats: AppearanceStats
+        let decision: AppearanceDecision
+    }
+
+    // The pin must keep reading like the ACTIVE window — it's the whole
+    // point of pinning. Every capture runs through correctorDecision (see
+    // the state block above for the model); this function does the pixel
+    // half: raw capture, stats, decision, and the corrected bitmap.
+    private func processCapture(of windowInfo: WindowInfo, context: AppearanceContext) -> ProcessedCapture? {
         // Quantize the capture rect to whole points. Window bounds are often
         // fractional; letting CG round a fractional rect makes the bitmap's
         // pixel size wobble between captures (visible as the pin shifting a
@@ -234,7 +359,7 @@ func exitSelectionMode() {
             width: windowInfo.bounds.width.rounded(),
             height: windowInfo.bounds.height.rounded()
         )
-        guard let fullImage = CGWindowListCreateImage(
+        guard let rawImage = CGWindowListCreateImage(
             captureRect,
             .optionIncludingWindow,
             windowInfo.id,
@@ -243,6 +368,17 @@ func exitSelectionMode() {
             NSLog("[PinTop] captureSnapshot returned NIL — preflight=\(CGPreflightScreenCaptureAccess()) id=\(windowInfo.id)")
             return nil
         }
+        guard let downsampled = Self.downsample(rawImage) else { return nil }
+        let captureStats = Self.computeStats(downsampled)
+        let decision = Self.correctorDecision(
+            anchor: context.anchor,
+            activeFit: context.activeFit,
+            pendingFit: context.pendingFit,
+            lastCapture: context.lastCapture,
+            freezeStreak: context.freezeStreak,
+            capture: downsampled,
+            captureStats: captureStats
+        )
 
         // Use the EXACT backing scale of the display hosting the window.
         // Deriving it as pixels/points of the (often fractional) window rect
@@ -250,48 +386,413 @@ func exitSelectionMode() {
         // resamples the whole bitmap by a fraction of a percent, which
         // softens all text. A whole-number dpi lets the view draw 1:1.
         let displayScale = Self.backingScale(for: windowInfo.bounds)
-        var cgImage = fullImage
-
-        // The pin must keep reading like the ACTIVE window — it's the whole
-        // point of pinning. When the snapshot is taken while the source app
-        // is inactive, macOS has already dimmed/desaturated the content in
-        // the window's own backing store, so invert that measured transform
-        // (inactive loses ~23% saturation, gains ~0.003 brightness and loses
-        // ~9% luma contrast — measured empirically). Without this the pin
-        // visibly changes color the moment the overlay takes over from the
-        // real window. Active-state captures get NO lift or colors would
-        // overshoot into over-saturation.
-        if !sourceIsActive, let lifted = Self.activeAppearanceLift(cgImage) {
-            cgImage = lifted
+        var displayImage: CGImage?
+        switch decision {
+        case .flow(let fit), .adopt(let fit):
+            displayImage = Self.applyCorrection(fit, to: rawImage) ?? rawImage
+        case .reanchor:
+            displayImage = rawImage
+        case .freeze:
+            displayImage = nil
         }
+        let image = displayImage.map {
+            // No edge crop: the capture's 1px window stroke stays in the
+            // bitmap and the bitmap fills the overlay edge to edge.
+            NSImage(
+                cgImage: $0,
+                size: CGSize(width: CGFloat($0.width) / displayScale, height: CGFloat($0.height) / displayScale)
+            )
+        }
+        return ProcessedCapture(image: image, stats: captureStats, decision: decision)
+    }
 
-        // No edge crop: the capture's 1px window stroke stays in the bitmap
-        // and the bitmap fills the overlay edge to edge. Cropping it created
-        // a 1pt transparent rim through which the real window's stroke (or
-        // the covering app) peeked — the actual "wrong edge" artifact.
-        return NSImage(
-            cgImage: cgImage,
-            size: CGSize(width: CGFloat(cgImage.width) / displayScale, height: CGFloat(cgImage.height) / displayScale)
+    /// Raw snapshot for the initial pin (main thread, once per pin).
+    private func captureRawSnapshot(of windowInfo: WindowInfo) -> (image: NSImage, stats: AppearanceStats)? {
+        let captureRect = CGRect(
+            x: windowInfo.bounds.minX.rounded(),
+            y: windowInfo.bounds.minY.rounded(),
+            width: windowInfo.bounds.width.rounded(),
+            height: windowInfo.bounds.height.rounded()
+        )
+        guard let rawImage = CGWindowListCreateImage(
+            captureRect,
+            .optionIncludingWindow,
+            windowInfo.id,
+            .bestResolution
+        ) else {
+            NSLog("[PinTop] initial capture NIL — preflight=\(CGPreflightScreenCaptureAccess()) id=\(windowInfo.id)")
+            return nil
+        }
+        guard let downsampled = Self.downsample(rawImage) else { return nil }
+        let displayScale = Self.backingScale(for: windowInfo.bounds)
+        return (
+            NSImage(
+                cgImage: rawImage,
+                size: CGSize(width: CGFloat(rawImage.width) / displayScale, height: CGFloat(rawImage.height) / displayScale)
+            ),
+            Self.computeStats(downsampled)
         )
     }
 
-    // Whole-number backing scale (1 or 2) of the display containing the
-    // rect's center; Retina is the sensible fallback if no display matches.
-    private static let ciContext = CIContext()
+    // MARK: Measured appearance correction
 
-    // Inverse of macOS's inactive-window dimming, measured empirically:
-    // an inactive window's content averages sat ×0.77, V +0.0034, luma
-    // contrast ×0.91 versus its active render. These values undo exactly
-    // that — see captureSnapshot for when the lift is applied.
-    private static func activeAppearanceLift(_ image: CGImage) -> CGImage? {
-        let input = CIImage(cgImage: image)
-        guard let controls = CIFilter(name: "CIColorControls") else { return nil }
-        controls.setValue(input, forKey: kCIInputImageKey)
-        controls.setValue(1.27, forKey: "inputSaturation")
-        controls.setValue(-0.02, forKey: "inputBrightness")
-        controls.setValue(1.10, forKey: "inputContrast")
-        guard let output = controls.outputImage else { return nil }
-        return ciContext.createCGImage(output, from: output.extent)
+    /// The heart of the color-stability fix. Classifies one capture against
+    /// the corrector state (pure function — unit-tested without windows):
+    ///
+    ///  1. Adjacent-frame gate (raw→raw): static content under a tone
+    ///     shift moves every luma cell by the same amount; content edits
+    ///     don't. Non-uniform → .flow (content, keep current correction).
+    ///  2. At or above the anchor (not dimmer, not desaturated): the window
+    ///     is in its target/active state — display raw and RE-SYNC the
+    ///     anchor to actual pixel stats (mappedStats is only an
+    ///     approximation; this is where drift is discarded). Also the
+    ///     ratchet: a window brightened past the anchor (focus regained)
+    ///     becomes the new anchor, and a pin created while dimmed
+    ///     self-heals on first focus.
+    ///  3. No change since the previous capture: if a candidate fit is
+    ///     pending, this frame confirms it (the appearance reached a
+    ///     stable state); otherwise flow with the current correction.
+    ///     Re-fitting in steady state is deliberately avoided — the
+    ///     two-stage fit is not a fixed point under anchor remapping and
+    ///     would oscillate between slightly different corrections.
+    ///  4. Near-solid frame (video black) → .flow; a bias-only "fit" would
+    ///     repaint it at the anchor's brightness.
+    ///  5. Dimmed vs anchor → fit the inverse (measureCorrection). Stable
+    ///     across two captures → .adopt; still moving (animation, video
+    ///     fade) → .freeze on the current bitmap until it settles.
+    static func correctorDecision(
+        anchor: AppearanceStats,
+        activeFit: AppearanceCorrection,
+        pendingFit: AppearanceCorrection?,
+        lastCapture: AppearanceStats,
+        freezeStreak: Int,
+        capture: DownsampledBitmap,
+        captureStats: AppearanceStats
+    ) -> AppearanceDecision {
+        // A resize changed the grid — stats aren't comparable; flow with the
+        // current correction and let a later brighten re-anchor.
+        let shift = adjacentShift(from: lastCapture, to: captureStats)
+        guard shift.uniform else {
+            return .flow(activeFit)
+        }
+
+        // Not dimmer and not desaturated vs the anchor → at target state.
+        let dimmerLuma = captureStats.lumaMedian < anchor.lumaMedian - 0.02
+        let dimmerChroma = captureStats.chromaMean < anchor.chromaMean * 0.85 - 0.004
+        if !dimmerLuma, !dimmerChroma {
+            return .reanchor(captureStats)
+        }
+
+        // Static appearance since the previous capture. Resolve any pending
+        // candidate (this is the confirmation frame), else nothing to do.
+        if abs(shift.lumaDelta) < 0.012, shift.chromaRatio <= 1.15 {
+            if let pending = pendingFit {
+                if let refit = measureCorrection(active: anchor, inactive: capture),
+                   correctionsMatch(pending, refit) {
+                    return .adopt(refit)
+                }
+                return .freeze(candidate: pending)
+            }
+            return .flow(activeFit)
+        }
+
+        if max(captureStats.channelSpread.x, captureStats.channelSpread.y, captureStats.channelSpread.z) < 0.015 {
+            return .flow(activeFit)
+        }
+
+        guard let fit = measureCorrection(active: anchor, inactive: capture) else {
+            // Adjacent-static but the content drifted from the anchor's
+            // content (anchor cells no longer match) — keep correcting with
+            // the confirmed transform instead of fitting against a stale
+            // reference.
+            return .flow(activeFit)
+        }
+        if correctionsMatch(fit, activeFit) {
+            return .flow(fit)
+        }
+        if let pending = pendingFit, correctionsMatch(pending, fit) {
+            return .adopt(fit)
+        }
+        if freezeStreak >= AppearanceConstants.maxFreezeStreak {
+            // Churn — every capture fits a different transform (video fade).
+            // Don't freeze the pin forever; flow with what we have.
+            return .flow(activeFit)
+        }
+        return .freeze(candidate: fit)
+    }
+
+    /// Comparison of consecutive raw captures: is the frame-to-frame delta
+    /// a spatially-uniform tone shift (appearance change over static
+    /// content), and if so by how much? Trimmed stats ignore a blinking
+    /// caret or a moved cursor occupying a few cells.
+    struct AdjacentShift: Equatable {
+        let uniform: Bool
+        /// Trimmed mean of per-cell luma deltas (previous − current), 0...1:
+        /// positive = the window got darker since the previous capture.
+        let lumaDelta: Float
+        /// previous.chroma / current.chroma: > 1 = desaturating.
+        let chromaRatio: Float
+    }
+
+    static func adjacentShift(from previous: AppearanceStats, to current: AppearanceStats) -> AdjacentShift {
+        guard previous.cellsX == current.cellsX, previous.cellsY == current.cellsY,
+              !previous.cellLuma.isEmpty, previous.cellLuma.count == current.cellLuma.count
+        else { return AdjacentShift(uniform: false, lumaDelta: 0, chromaRatio: 1) }
+        let deltas = zip(previous.cellLuma, current.cellLuma).map { $0 - $1 }
+        let (mean, std) = trimmedMeanStd(deltas)
+        let ratio = current.chromaMean > 0.004 ? previous.chromaMean / current.chromaMean : 1
+        return AdjacentShift(
+            uniform: std <= max(0.02, 0.33 * abs(mean)),
+            lumaDelta: mean,
+            chromaRatio: ratio
+        )
+    }
+
+    /// Anchor bookkeeping after adopting a fit: the anchor must keep
+    /// describing the CURRENT content at the TARGET (active) appearance —
+    /// mapped through the correction the same way applyCorrection maps
+    /// pixels — or future fits would gate against stale content.
+    static func mappedStats(_ stats: AppearanceStats, through fit: AppearanceCorrection) -> AppearanceStats {
+        var out = stats
+        let luma = stats.lumaMedian
+        // Saturation stage: channels move away from luma by the factor;
+        // luma itself is invariant under lerp-toward-luma.
+        for channel in 0..<3 {
+            out.channelMedian[channel] = luma + fit.saturation * (stats.channelMedian[channel] - luma)
+            out.channelSpread[channel] = fit.saturation * stats.channelSpread[channel]
+        }
+        // Affine stage.
+        let averageScale = (fit.channelScale.x + fit.channelScale.y + fit.channelScale.z) / 3
+        for channel in 0..<3 {
+            out.channelMedian[channel] = fit.channelScale[channel] * out.channelMedian[channel] + fit.channelBias[channel]
+            out.channelSpread[channel] = fit.channelScale[channel] * out.channelSpread[channel]
+        }
+        out.chromaMean = stats.chromaMean * fit.saturation * averageScale
+        out.lumaMedian = 0.2126 * out.channelMedian.x + 0.7152 * out.channelMedian.y + 0.0722 * out.channelMedian.z
+        // Scalar cell luma: unchanged by the saturation stage (luma is
+        // invariant), shifted/stretched by the affine stage.
+        out.cellLuma = stats.cellLuma.map {
+            $0 + (out.lumaMedian - stats.lumaMedian) + (averageScale - 1) * ($0 - stats.lumaMedian)
+        }
+        return out
+    }
+
+    /// Fit the inverse of this window's dimming: a saturation factor to
+    /// undo lerp-toward-gray, then a per-channel affine (scale+bias)
+    /// matching the boosted dimmed stats onto the anchor ones. Returns nil
+    /// when the frames aren't comparable (grid mismatch, or non-uniform
+    /// deltas meaning content changed vs the anchor). Returns identity
+    /// when there is no dimming to invert.
+    static func measureCorrection(active: AppearanceStats, inactive inactiveBitmap: DownsampledBitmap) -> AppearanceCorrection? {
+        let inactive = computeStats(inactiveBitmap)
+        guard adjacentShift(from: active, to: inactive).uniform
+        else { return nil }
+
+        let chromaRatio = inactive.chromaMean > 0.004 ? active.chromaMean / inactive.chromaMean : 1
+        let deltas = zip(active.cellLuma, inactive.cellLuma).map { $0 - $1 }
+        let (deltaMean, _) = trimmedMeanStd(deltas)
+        if abs(deltaMean) < 0.012, chromaRatio <= 1.15 {
+            return AppearanceCorrection() // no dimming to invert
+        }
+
+        var correction = AppearanceCorrection()
+        correction.saturation = chromaRatio > 1.15 ? min(6, chromaRatio) : 1
+
+        // Fit the affine on the PREDICTED saturation-boosted pixels — the
+        // same operation applyCorrection runs first — so both stages
+        // compose into one transform landing on the active stats.
+        let count = inactiveBitmap.width * inactiveBitmap.height
+        var boostedR = [Float](); boostedR.reserveCapacity(count)
+        var boostedG = [Float](); boostedG.reserveCapacity(count)
+        var boostedB = [Float](); boostedB.reserveCapacity(count)
+        for offset in stride(from: 0, to: inactiveBitmap.rgba.count, by: 4) {
+            var r = Float(inactiveBitmap.rgba[offset]) / 255
+            var g = Float(inactiveBitmap.rgba[offset + 1]) / 255
+            var b = Float(inactiveBitmap.rgba[offset + 2]) / 255
+            if correction.saturation != 1 {
+                let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b
+                r = min(max(luma + correction.saturation * (r - luma), 0), 1)
+                g = min(max(luma + correction.saturation * (g - luma), 0), 1)
+                b = min(max(luma + correction.saturation * (b - luma), 0), 1)
+            }
+            boostedR.append(r)
+            boostedG.append(g)
+            boostedB.append(b)
+        }
+        let boosted = [boostedR, boostedG, boostedB]
+        for channel in 0..<3 {
+            let median = median(of: boosted[channel])
+            let spread = robustSpread(of: boosted[channel], around: median)
+            var scale: Float = 1
+            if spread > 0.01, active.channelSpread[channel] > 0.01 {
+                scale = min(4, max(0.6, active.channelSpread[channel] / spread))
+                if abs(scale - 1) < 0.03 { scale = 1 }
+            }
+            correction.channelScale[channel] = scale
+            correction.channelBias[channel] = active.channelMedian[channel] - scale * median
+        }
+        return correction
+    }
+
+    /// Apply a measured correction directly on an sRGB RGBA8 bitmap — no
+    /// CIFilter color-space ambiguity between how the transform was measured
+    /// (sRGB stats) and how it is applied. Runs on captureQueue at idle
+    /// cadence; a full Retina window is a few ms of float math.
+    static func applyCorrection(_ correction: AppearanceCorrection, to image: CGImage) -> CGImage? {
+        if correction.isIdentity { return image }
+        let width = image.width, height = image.height
+        guard width > 0, height > 0,
+              let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              )
+        else { return nil }
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        guard let base = context.data else { return nil }
+        let pixels = base.assumingMemoryBound(to: UInt8.self)
+        let saturation = correction.saturation
+        let scale = correction.channelScale
+        let bias = correction.channelBias
+        for offset in stride(from: 0, to: width * height * 4, by: 4) {
+            var r = Float(pixels[offset])
+            var g = Float(pixels[offset + 1])
+            var b = Float(pixels[offset + 2])
+            if saturation != 1 {
+                let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b
+                r = luma + saturation * (r - luma)
+                g = luma + saturation * (g - luma)
+                b = luma + saturation * (b - luma)
+            }
+            r = scale.x * r + bias.x * 255
+            g = scale.y * g + bias.y * 255
+            b = scale.z * b + bias.z * 255
+            pixels[offset] = UInt8(min(255, max(0, r)))
+            pixels[offset + 1] = UInt8(min(255, max(0, g)))
+            pixels[offset + 2] = UInt8(min(255, max(0, b)))
+        }
+        return context.makeImage()
+    }
+
+    /// ≤96px RGBA8 copy for statistics. Small enough that median/MAD over
+    /// all pixels is microseconds; large enough that text and chrome still
+    /// influence the stats at realistic proportions.
+    static func downsample(_ image: CGImage) -> DownsampledBitmap? {
+        let maxDimension = 96
+        let w0 = image.width, h0 = image.height
+        guard w0 > 0, h0 > 0 else { return nil }
+        var width = min(maxDimension, w0)
+        var height = max(1, Int((CGFloat(width) * CGFloat(h0) / CGFloat(w0)).rounded()))
+        if height > maxDimension {
+            height = maxDimension
+            width = max(1, Int((CGFloat(height) * CGFloat(w0) / CGFloat(h0)).rounded()))
+        }
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.interpolationQuality = .medium
+        context.draw(image, in: CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
+        guard let data = context.data else { return nil }
+        let pointer = data.assumingMemoryBound(to: UInt8.self)
+        return DownsampledBitmap(
+            width: width,
+            height: height,
+            rgba: Array(UnsafeBufferPointer(start: pointer, count: width * height * 4))
+        )
+    }
+
+    static func computeStats(_ bitmap: DownsampledBitmap) -> AppearanceStats {
+        var stats = AppearanceStats()
+        let cellsX = min(12, bitmap.width)
+        let cellsY = min(12, bitmap.height)
+        var cellBuckets = [[Float]](repeating: [], count: cellsX * cellsY)
+        let pixelCount = bitmap.width * bitmap.height
+        var reds = [Float](); reds.reserveCapacity(pixelCount)
+        var greens = [Float](); greens.reserveCapacity(pixelCount)
+        var blues = [Float](); blues.reserveCapacity(pixelCount)
+        var chromaSum: Float = 0
+
+        for y in 0..<bitmap.height {
+            let cellY = min(cellsY - 1, y * cellsY / bitmap.height)
+            for x in 0..<bitmap.width {
+                let cellX = min(cellsX - 1, x * cellsX / bitmap.width)
+                let offset = (y * bitmap.width + x) * 4
+                let r = Float(bitmap.rgba[offset]) / 255
+                let g = Float(bitmap.rgba[offset + 1]) / 255
+                let b = Float(bitmap.rgba[offset + 2]) / 255
+                reds.append(r)
+                greens.append(g)
+                blues.append(b)
+                chromaSum += max(r, g, b) - min(r, g, b)
+                let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b
+                cellBuckets[cellY * cellsX + cellX].append(luma)
+            }
+        }
+
+        let channels = [reds, greens, blues]
+        for channel in 0..<3 {
+            let median = median(of: channels[channel])
+            stats.channelMedian[channel] = median
+            stats.channelSpread[channel] = robustSpread(of: channels[channel], around: median)
+        }
+        stats.chromaMean = pixelCount > 0 ? chromaSum / Float(pixelCount) : 0
+        stats.cellLuma = cellBuckets.map { median(of: $0) }
+        stats.lumaMedian = median(of: stats.cellLuma)
+        stats.cellsX = cellsX
+        stats.cellsY = cellsY
+        return stats
+    }
+
+    /// Whether two measured corrections are close enough to count as the
+    /// same transform — the confirmation step that guards against measuring
+    /// mid-animation (a half-faded frame yields a systematically weaker
+    /// correction than the settled one two ticks later).
+    static func correctionsMatch(_ a: AppearanceCorrection, _ b: AppearanceCorrection) -> Bool {
+        abs(a.saturation - b.saturation) <= 0.3
+            && abs(a.channelScale.x - b.channelScale.x) <= 0.15
+            && abs(a.channelScale.y - b.channelScale.y) <= 0.15
+            && abs(a.channelScale.z - b.channelScale.z) <= 0.15
+            && abs(a.channelBias.x - b.channelBias.x) <= 0.05
+            && abs(a.channelBias.y - b.channelBias.y) <= 0.05
+            && abs(a.channelBias.z - b.channelBias.z) <= 0.05
+    }
+
+    private static func median(of values: [Float]) -> Float {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let mid = sorted.count / 2
+        if sorted.count % 2 == 0 {
+            return (sorted[mid - 1] + sorted[mid]) / 2
+        }
+        return sorted[mid]
+    }
+
+    /// MAD × 1.4826 — a standard deviation estimate that ignores outliers
+    /// (a blinking caret or moved cursor between captures must not skew the
+    /// fitted transform).
+    private static func robustSpread(of values: [Float], around center: Float) -> Float {
+        1.4826 * median(of: values.map { abs($0 - center) })
+    }
+
+    /// Mean and std with the outer 10% trimmed from each side.
+    private static func trimmedMeanStd(_ values: [Float]) -> (mean: Float, std: Float) {
+        guard values.count >= 4 else { return (0, 0) }
+        let sorted = values.sorted()
+        let trim = sorted.count / 10
+        let kept = Array(sorted[trim ..< sorted.count - trim])
+        let mean = kept.reduce(0, +) / Float(kept.count)
+        let variance = kept.reduce(0) { $0 + ($1 - mean) * ($1 - mean) } / Float(kept.count)
+        return (mean, variance.squareRoot())
     }
 
     private static func backingScale(for rect: CGRect) -> CGFloat {
@@ -314,8 +815,7 @@ func exitSelectionMode() {
         // Capture initial snapshot. A nil result reliably means Screen
         // Recording permission is missing on macOS 10.15+ — surface the
         // prompt, but only once per session so the user isn't badgered.
-        let sourceActiveAtPin = NSWorkspace.shared.frontmostApplication?.processIdentifier == window.pid
-        guard let snapshot = captureSnapshot(of: window, sourceIsActive: sourceActiveAtPin) else {
+        guard let captured = captureRawSnapshot(of: window) else {
             if !hasPromptedScreenCaptureThisSession {
                 hasPromptedScreenCaptureThisSession = true
                 requestScreenCapturePermission()
@@ -323,6 +823,15 @@ func exitSelectionMode() {
             }
             return
         }
+        // Seed the appearance corrector: the anchor is whatever the window
+        // looks like right now (ideally its active state). If the window
+        // was dimmed at pin time, the first focus regained brightens past
+        // this anchor and re-anchors — the pin self-heals.
+        anchorStats[window.id] = captured.stats
+        lastCaptureStats[window.id] = captured.stats
+        activeFit[window.id] = AppearanceCorrection()
+        pendingFit[window.id] = nil
+        freezeStreaks[window.id] = 0
 
         pinnedWindows.insert(window)
 
@@ -335,7 +844,7 @@ func exitSelectionMode() {
         // Create overlay window
         let overlay = PinOverlayWindow(
             frame: appKitFrame(for: window.bounds),
-            snapshot: snapshot,
+            snapshot: captured.image,
             windowID: window.id,
             pid: window.pid
         )
@@ -390,6 +899,11 @@ func exitSelectionMode() {
         lastOcclusionReason.removeAll()
         offScreenStreaks.removeAll()
         windowMissStreaks.removeAll()
+        anchorStats.removeAll()
+        activeFit.removeAll()
+        pendingFit.removeAll()
+        lastCaptureStats.removeAll()
+        freezeStreaks.removeAll()
         for overlay in snapshot {
             overlay.orderOut(nil)
         }
@@ -414,6 +928,11 @@ func exitSelectionMode() {
         lastOcclusionReason.removeValue(forKey: windowID)
         offScreenStreaks.removeValue(forKey: windowID)
         windowMissStreaks.removeValue(forKey: windowID)
+        anchorStats.removeValue(forKey: windowID)
+        activeFit.removeValue(forKey: windowID)
+        pendingFit.removeValue(forKey: windowID)
+        lastCaptureStats.removeValue(forKey: windowID)
+        freezeStreaks.removeValue(forKey: windowID)
     }
 
     // MARK: - Accessibility
@@ -514,7 +1033,6 @@ func exitSelectionMode() {
             // buried pinned window (pin vanished — "always-on-top not
             // working"), and a raised-but-not-focused window got the overlay
             // re-shown over the exposed real window (flash/double image).
-            let sourceIsFrontmost = frontmostPID == currentWindow.pid
             if (now - (lastOcclusionScanTime[window.id] ?? 0)) >= occlusionScanInterval {
                 lastOcclusionScanTime[window.id] = now
                 var hide: Bool
@@ -651,19 +1169,50 @@ func exitSelectionMode() {
             if settleRecaptureDue {
                 lastBoundsChangeTime[window.id] = 0
             }
+            // Snapshot the corrector state for this capture; pin() seeds it,
+            // so the fallbacks only matter for state left by older builds.
+            let context = AppearanceContext(
+                anchor: anchorStats[window.id] ?? lastCaptureStats[window.id] ?? AppearanceStats(),
+                activeFit: activeFit[window.id] ?? AppearanceCorrection(),
+                pendingFit: pendingFit[window.id],
+                lastCapture: lastCaptureStats[window.id] ?? anchorStats[window.id] ?? AppearanceStats(),
+                freezeStreak: freezeStreaks[window.id] ?? 0
+            )
+            let wid = window.id
+            let overlayRef = overlay
             // Off-main capture. Snapshot is read-only against the source's
             // CGWindowID, so it's safe to run on a background queue. The
             // bitmap apply hops back to main, where NSImageView lives.
-            // sourceIsFrontmost decides whether the inactive-dimming lift
-            // applies — sampled at enqueue time, close enough to capture.
-            let wid = window.id
-            let overlayRef = overlay
             captureQueue.async { [weak self] in
-                guard let snapshot = self?.captureSnapshot(of: currentWindow, sourceIsActive: sourceIsFrontmost) else { return }
-                DispatchQueue.main.async {
+                guard let processed = self?.processCapture(of: currentWindow, context: context) else { return }
+                DispatchQueue.main.async { [weak self] in
                     // Bail if the pin was released while we were capturing.
-                    guard self?.overlays[wid] === overlayRef else { return }
-                    overlayRef.updateSnapshot(snapshot)
+                    guard let self, self.overlays[wid] === overlayRef else { return }
+                    self.lastCaptureStats[wid] = processed.stats
+                    switch processed.decision {
+                    case .flow:
+                        self.pendingFit[wid] = nil
+                        self.freezeStreaks[wid] = 0
+                    case .adopt(let fit):
+                        self.activeFit[wid] = fit
+                        // Keep the anchor describing current content at the
+                        // target appearance (see mappedStats).
+                        self.anchorStats[wid] = Self.mappedStats(processed.stats, through: fit)
+                        self.pendingFit[wid] = nil
+                        self.freezeStreaks[wid] = 0
+                    case .reanchor(let stats):
+                        self.anchorStats[wid] = stats
+                        self.activeFit[wid] = AppearanceCorrection()
+                        self.pendingFit[wid] = nil
+                        self.freezeStreaks[wid] = 0
+                    case .freeze(let candidate):
+                        self.pendingFit[wid] = candidate
+                        self.freezeStreaks[wid] = (self.freezeStreaks[wid] ?? 0) + 1
+                        return // keep displaying the current bitmap
+                    }
+                    if let image = processed.image {
+                        overlayRef.updateSnapshot(image)
+                    }
                 }
             }
         }

--- a/Tests/PinTopTests/AppearanceCorrectionTests.swift
+++ b/Tests/PinTopTests/AppearanceCorrectionTests.swift
@@ -1,0 +1,311 @@
+import XCTest
+@testable import PinTop
+
+/// Tests for the appearance corrector: a synthetic "window" whose pixels
+/// transform a known way when it loses key/focus must be detected, measured
+/// and inverted back to (approximately) its anchored statistics — the
+/// mathematical core of the pin-doesn't-change-color fix. Covers both
+/// triggers: app deactivation and Chromium-style per-window dimming (which
+/// happens with the app still frontmost, so no app-level signal exists).
+final class AppearanceCorrectionTests: XCTestCase {
+
+    private func syntheticBitmap(
+        width: Int = 48,
+        height: Int = 32,
+        transform: (Float, Float, Float) -> (Float, Float, Float)
+    ) -> DownsampledBitmap {
+        var rgba = [UInt8](repeating: 0, count: width * height * 4)
+        for y in 0..<height {
+            for x in 0..<width {
+                // Gradients + channel separation so medians, spreads, chroma
+                // and the luma grid all carry signal.
+                let r = 0.15 + 0.5 * Float(x) / Float(width)
+                let g = 0.25 + 0.4 * Float(y) / Float(height)
+                let b = 0.35 + 0.3 * (1 - Float(x) / Float(width))
+                let (tr, tg, tb) = transform(r, g, b)
+                let offset = (y * width + x) * 4
+                rgba[offset] = UInt8(min(255, max(0, tr * 255)))
+                rgba[offset + 1] = UInt8(min(255, max(0, tg * 255)))
+                rgba[offset + 2] = UInt8(min(255, max(0, tb * 255)))
+                rgba[offset + 3] = 255
+            }
+        }
+        return DownsampledBitmap(width: width, height: height, rgba: rgba)
+    }
+
+    private func solidBitmap(color: Float, width: Int = 48, height: Int = 32) -> DownsampledBitmap {
+        syntheticBitmap { _, _, _ in (color, color, color) }
+    }
+
+    /// Chromium-style inactive restyle: desaturate toward luma, then dim.
+    private func dimmingTransform(desat: Float, brightness: Float) -> (Float, Float, Float) -> (Float, Float, Float) {
+        { r, g, b in
+            let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b
+            return (
+                (luma + desat * (r - luma)) * brightness,
+                (luma + desat * (g - luma)) * brightness,
+                (luma + desat * (b - luma)) * brightness
+            )
+        }
+    }
+
+    private func cgImage(from bitmap: DownsampledBitmap) -> CGImage? {
+        var rgba = bitmap.rgba
+        return rgba.withUnsafeMutableBytes { buffer -> CGImage? in
+            guard let base = buffer.baseAddress,
+                  let context = CGContext(
+                    data: base,
+                    width: bitmap.width,
+                    height: bitmap.height,
+                    bitsPerComponent: 8,
+                    bytesPerRow: bitmap.width * 4,
+                    space: CGColorSpaceCreateDeviceRGB(),
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                  )
+            else { return nil }
+            return context.makeImage()
+        }
+    }
+
+    private func decision(
+        anchor: AppearanceStats,
+        activeFit: AppearanceCorrection = AppearanceCorrection(),
+        pendingFit: AppearanceCorrection? = nil,
+        lastCapture: AppearanceStats,
+        freezeStreak: Int = 0,
+        capture: DownsampledBitmap
+    ) -> AppearanceDecision {
+        WindowManager.correctorDecision(
+            anchor: anchor,
+            activeFit: activeFit,
+            pendingFit: pendingFit,
+            lastCapture: lastCapture,
+            freezeStreak: freezeStreak,
+            capture: capture,
+            captureStats: WindowManager.computeStats(capture)
+        )
+    }
+
+    // MARK: - Fit + apply round trips
+
+    func testMeasuresAndInvertsHeavyDimming() {
+        let active = syntheticBitmap(transform: { ($0, $1, $2) })
+        let inactive = syntheticBitmap(transform: dimmingTransform(desat: 0.2, brightness: 0.55))
+        let activeStats = WindowManager.computeStats(active)
+
+        guard let correction = WindowManager.measureCorrection(active: activeStats, inactive: inactive) else {
+            return XCTFail("gate rejected a static, uniformly dimmed window")
+        }
+        XCTAssertFalse(correction.isIdentity, "heavy dimming must produce a non-identity correction")
+
+        // Round trip: the corrected bitmap must land back on the active
+        // statistics — that is the whole point of the transform.
+        guard let image = cgImage(from: inactive),
+              let corrected = WindowManager.applyCorrection(correction, to: image),
+              let correctedDown = WindowManager.downsample(corrected)
+        else { return XCTFail("correction pipeline returned nil") }
+        let correctedStats = WindowManager.computeStats(correctedDown)
+
+        // 1/desat = 5 in theory; heavy desat leaves chroma near the 8-bit
+        // noise floor, which inflates the ratio up to the clamp at 6 — the
+        // affine stage absorbs whatever the saturation factor overshoots.
+        XCTAssertTrue((4.5...6.0).contains(correction.saturation), "saturation factor \(correction.saturation) out of range")
+        for channel in 0..<3 {
+            XCTAssertEqual(correctedStats.channelMedian[channel], activeStats.channelMedian[channel], accuracy: 0.03)
+            XCTAssertEqual(correctedStats.channelSpread[channel], activeStats.channelSpread[channel], accuracy: 0.03)
+        }
+        XCTAssertEqual(correctedStats.chromaMean, activeStats.chromaMean, accuracy: activeStats.chromaMean * 0.2)
+    }
+
+    func testModerateSystemStyleDimming() {
+        // The subtle system-level change (inactive chrome dimming).
+        let active = syntheticBitmap(transform: { ($0, $1, $2) })
+        let inactive = syntheticBitmap(transform: dimmingTransform(desat: 0.77, brightness: 0.95))
+        let activeStats = WindowManager.computeStats(active)
+
+        guard let correction = WindowManager.measureCorrection(active: activeStats, inactive: inactive),
+              let image = cgImage(from: inactive),
+              let corrected = WindowManager.applyCorrection(correction, to: image),
+              let correctedDown = WindowManager.downsample(corrected)
+        else { return XCTFail("pipeline returned nil for moderate dimming") }
+        let correctedStats = WindowManager.computeStats(correctedDown)
+        for channel in 0..<3 {
+            XCTAssertEqual(correctedStats.channelMedian[channel], activeStats.channelMedian[channel], accuracy: 0.03)
+        }
+    }
+
+    func testNoDimmingYieldsIdentity() {
+        let active = syntheticBitmap(transform: { ($0, $1, $2) })
+        let activeStats = WindowManager.computeStats(active)
+        XCTAssertEqual(WindowManager.measureCorrection(active: activeStats, inactive: active), AppearanceCorrection())
+    }
+
+    func testContentChangeFailsGate() {
+        // A localized content edit between captures must NOT be mistaken
+        // for an appearance change — the measurement returns nil.
+        let active = syntheticBitmap(transform: { ($0, $1, $2) })
+        let activeStats = WindowManager.computeStats(active)
+
+        // Brighten one quadrant the way real content (video frame, new
+        // message) would — spatially non-uniform, unlike a tone shift.
+        var rgba = active.rgba
+        for y in 16..<active.height {
+            for x in 24..<active.width {
+                let offset = (y * active.width + x) * 4
+                for channel in 0..<3 {
+                    rgba[offset + channel] = UInt8(min(255, Float(rgba[offset + channel]) + 76))
+                }
+            }
+        }
+        let edited = DownsampledBitmap(width: active.width, height: active.height, rgba: rgba)
+        XCTAssertNil(WindowManager.measureCorrection(active: activeStats, inactive: edited))
+    }
+
+    func testCorrectionsMatchTolerances() {
+        var a = AppearanceCorrection()
+        a.saturation = 5
+        a.channelScale = SIMD3<Float>(repeating: 1.8)
+        var b = a
+        b.saturation = 5.2
+        b.channelBias = SIMD3<Float>(repeating: 0.03)
+        XCTAssertTrue(WindowManager.correctionsMatch(a, b))
+        b.saturation = 5.6
+        XCTAssertFalse(WindowManager.correctionsMatch(a, b))
+    }
+
+    // MARK: - Corrector decisions
+
+    func testDimmingFreezesThenAdopts() {
+        // The reported bug scenario: window dims (intra-app focus loss).
+        // Frame 1: uniform shift vs the previous (bright) capture → freeze,
+        // the pin keeps its bright bitmap. Frame 2: nothing changed since
+        // frame 1, pending candidate re-fits identically → adopt.
+        let bright = syntheticBitmap(transform: { ($0, $1, $2) })
+        let anchor = WindowManager.computeStats(bright)
+        let dimmed = syntheticBitmap(transform: dimmingTransform(desat: 0.2, brightness: 0.55))
+        let dimStats = WindowManager.computeStats(dimmed)
+
+        let first = decision(anchor: anchor, lastCapture: anchor, capture: dimmed)
+        guard case .freeze(let candidate) = first else {
+            return XCTFail("first dimmed frame should freeze, got \(first)")
+        }
+        XCTAssertFalse(candidate.isIdentity)
+        let second = decision(anchor: anchor, pendingFit: candidate, lastCapture: dimStats, freezeStreak: 1, capture: dimmed)
+        guard case .adopt = second else {
+            return XCTFail("confirmation frame should adopt, got \(second)")
+        }
+    }
+
+    func testBrighteningReanchors() {
+        // Focus regained: the window comes back brighter than the anchor →
+        // show raw and ratchet the anchor (also the self-heal path for a
+        // pin created while the window was dimmed).
+        let dimmed = syntheticBitmap(transform: dimmingTransform(desat: 0.2, brightness: 0.55))
+        let dimStats = WindowManager.computeStats(dimmed)
+        let bright = syntheticBitmap(transform: { ($0, $1, $2) })
+        let brightStats = WindowManager.computeStats(bright)
+
+        // Simulate the adopted-dim state: anchor already maps to the bright
+        // look, capture goes BRIGHT past it.
+        let anchor = WindowManager.mappedStats(dimStats, through: WindowManager.measureCorrection(active: brightStats, inactive: dimmed)!)
+        let result = decision(anchor: anchor, lastCapture: dimStats, capture: bright)
+        guard case .reanchor(let stats) = result else {
+            return XCTFail("brightened window should reanchor, got \(result)")
+        }
+        XCTAssertEqual(stats, brightStats)
+    }
+
+    func testLocalizedContentChangeFlowsWithCurrentCorrection() {
+        // While dimmed with an adopted fit, a real content edit (chat
+        // message, terminal output) must flow through WITH the correction —
+        // content freshness without losing the active look.
+        let bright = syntheticBitmap(transform: { ($0, $1, $2) })
+        let anchor = WindowManager.computeStats(bright)
+        let dimmed = syntheticBitmap(transform: dimmingTransform(desat: 0.2, brightness: 0.55))
+        let fit = WindowManager.measureCorrection(active: anchor, inactive: dimmed)!
+
+        var rgba = dimmed.rgba
+        for y in 16..<dimmed.height {
+            for x in 24..<dimmed.width {
+                let offset = (y * dimmed.width + x) * 4
+                for channel in 0..<3 {
+                    rgba[offset + channel] = UInt8(min(255, Float(rgba[offset + channel]) + 60))
+                }
+            }
+        }
+        let editedDim = DownsampledBitmap(width: dimmed.width, height: dimmed.height, rgba: rgba)
+
+        let result = decision(anchor: anchor, activeFit: fit, lastCapture: WindowManager.computeStats(dimmed), capture: editedDim)
+        guard case .flow(let flowed) = result else {
+            return XCTFail("content change should flow, got \(result)")
+        }
+        XCTAssertEqual(flowed, fit, "content frames must keep the adopted correction")
+    }
+
+    func testSolidFrameFlowsWithoutBiasLift() {
+        // Fullscreen near-solid video frame (fade to black): must flow with
+        // the current correction, never get a bias-only "lift" that would
+        // repaint it at the anchor's brightness.
+        let previousSolid = solidBitmap(color: 0.25)
+        let blackSolid = solidBitmap(color: 0.02)
+        let anchorStats = WindowManager.computeStats(syntheticBitmap(transform: { ($0, $1, $2) }))
+        let result = decision(anchor: anchorStats,
+                              lastCapture: WindowManager.computeStats(previousSolid),
+                              capture: blackSolid)
+        guard case .flow = result else {
+            return XCTFail("solid frame should flow, got \(result)")
+        }
+    }
+
+    func testFreezeStreakBoundFlows() {
+        // A continuously-drifting appearance (video fade) must not freeze
+        // the pin forever: past the streak bound we flow with the last
+        // confirmed correction.
+        let bright = syntheticBitmap(transform: { ($0, $1, $2) })
+        let anchor = WindowManager.computeStats(bright)
+        let dimmed = syntheticBitmap(transform: dimmingTransform(desat: 0.3, brightness: 0.7))
+        let result = decision(anchor: anchor,
+                              pendingFit: nil,
+                              lastCapture: anchor,
+                              freezeStreak: 6,
+                              capture: dimmed)
+        guard case .flow = result else {
+            return XCTFail("exceeded freeze streak should flow, got \(result)")
+        }
+    }
+
+    func testMappedStatsTracksContentThroughFit() {
+        // After adopting a fit, the anchor must describe the CURRENT
+        // content at the TARGET appearance, or future fits gate against
+        // stale content and never fire.
+        let bright = syntheticBitmap(transform: { ($0, $1, $2) })
+        let anchor = WindowManager.computeStats(bright)
+        let dimmed = syntheticBitmap(transform: dimmingTransform(desat: 0.2, brightness: 0.55))
+        let fit = WindowManager.measureCorrection(active: anchor, inactive: dimmed)!
+        let mapped = WindowManager.mappedStats(WindowManager.computeStats(dimmed), through: fit)
+        XCTAssertEqual(mapped.lumaMedian, anchor.lumaMedian, accuracy: 0.05)
+        XCTAssertEqual(mapped.chromaMean, anchor.chromaMean, accuracy: anchor.chromaMean * 0.25)
+        for channel in 0..<3 {
+            XCTAssertEqual(mapped.channelMedian[channel], anchor.channelMedian[channel], accuracy: 0.05)
+        }
+    }
+
+    func testSteadyDimmedStateFlowsWithoutRefitting() {
+        // Once adopted, an unchanged capture must flow with the stored fit —
+        // re-fitting against the remapped anchor is not a fixed point and
+        // would oscillate between slightly different corrections.
+        let bright = syntheticBitmap(transform: { ($0, $1, $2) })
+        let anchor = WindowManager.computeStats(bright)
+        let dimmed = syntheticBitmap(transform: dimmingTransform(desat: 0.2, brightness: 0.55))
+        let dimStats = WindowManager.computeStats(dimmed)
+        let fit = WindowManager.measureCorrection(active: anchor, inactive: dimmed)!
+        let result = decision(anchor: WindowManager.mappedStats(dimStats, through: fit),
+                              activeFit: fit,
+                              lastCapture: dimStats,
+                              capture: dimmed)
+        guard case .flow(let flowed) = result else {
+            return XCTFail("steady dimmed state should flow, got \(result)")
+        }
+        XCTAssertEqual(flowed, fit)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the pinned window visibly changing color the moment you click any window behind it. The screenshot diff of the original repro measured the pinned Figma plugin window dropping to **luma ×0.47 and saturation ×0.19** on click-away.

## Root cause

The "Creat…" plugin window (like many Chromium/Electron windows) fades its **entire content** when it loses *key-window* status — and that happens **within the same app**: clicking the Figma canvas behind the pin dims the plugin window while Figma stays frontmost, so no app-activation event exists to key on. The dimming is baked into the window's backing store, so every recapture carried it into the pin. The previous fixed "inactive lift" constants (sat ×1.27 etc.) were tuned for the subtle system-level inactive effect and were nowhere near enough for app-level CSS dimming.

## Changes

`WindowManager.swift` — the fixed lift is replaced by a per-window **appearance corrector** driven entirely by capture statistics (no focus tracking, no extra permissions):

- **Adjacent-frame gate** (raw capture → raw capture): a spatially uniform tone shift over static content is an appearance change; localized deltas are real content changes and flow through untouched.
- **Measured inverse**: on dimming, the pin freezes on its last bright bitmap while the animation settles, then fits this window's own inverse transform (saturation boost for lerp-to-gray desaturation + per-channel affine for brightness/contrast), measured on a ≤96px downsample with robust median/MAD stats, applied directly in sRGB RGBA8 so measurement and application match exactly. Two consecutive captures must agree before the transform is adopted.
- **Re-anchor**: a capture at or above the anchored "active" look displays raw and re-syncs the anchor to real pixel stats — this handles focus-regained, discards accumulated approximation drift, and lets a pin created while dimmed self-heal on first focus.
- **Safety rails**: fullscreen near-solid frames (video black) never get a bias-only lift; a continuously drifting fade can't freeze the pin longer than ~6 frames; steady dimmed state never re-fits (the fit is not a fixed point under anchor remapping and would oscillate).

`Tests/PinTopTests/AppearanceCorrectionTests.swift` — new: fit/apply round-trips at the measured dimming magnitude (desat ×0.2, brightness ×0.55) and moderate system-level dimming, gate rejection for localized content edits, identity for non-dimming windows, and full `correctorDecision` coverage (freeze → adopt, reanchor, content flow, solid-frame and freeze-streak bail-outs).

## Testing

- [x] `swift test` — 29/29 pass
- [x] Built and ran locally via `run.sh`
- [ ] Manual: pin the Figma plugin window (⌥⌘P + click), click the canvas behind it — color should hold through a sub-second transition
